### PR TITLE
Add WebDriver Manager

### DIFF
--- a/selenium/junit/pom.xml
+++ b/selenium/junit/pom.xml
@@ -4,8 +4,8 @@
   <artifactId>junit</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <junit.version>5.6.0</junit.version>
     <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
@@ -39,6 +39,11 @@
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-java</artifactId>
       <version>4.0.0-alpha-7</version>
+    </dependency>
+    <dependency>
+      <groupId>io.github.bonigarcia</groupId>
+      <artifactId>webdrivermanager</artifactId>
+      <version>5.0.2</version>
     </dependency>
   </dependencies>
   <build>

--- a/selenium/junit/src/main/java/junit/App.java
+++ b/selenium/junit/src/main/java/junit/App.java
@@ -1,12 +1,12 @@
 /**
  * VVS by Rodrigo Prestes Machado
- * 
  * VVS is licensed under a
  * Creative Commons Attribution 4.0 International License.
  * You should have received a copy of the license along with this
  * work. If not, see <http://creativecommons.org/licenses/by/4.0/>.
  *
 */
+
 package junit;
 
 /**

--- a/selenium/junit/src/test/java/junit/AppTest.java
+++ b/selenium/junit/src/test/java/junit/AppTest.java
@@ -1,12 +1,12 @@
 /**
  * VVS by Rodrigo Prestes Machado
- * 
  * VVS is licensed under a
  * Creative Commons Attribution 4.0 International License.
  * You should have received a copy of the license along with this
  * work. If not, see <http://creativecommons.org/licenses/by/4.0/>.
  *
 */
+
 package junit;
 
 import org.junit.jupiter.api.Test;

--- a/selenium/junit/src/test/java/junit/WebTest.java
+++ b/selenium/junit/src/test/java/junit/WebTest.java
@@ -1,23 +1,24 @@
 /**
  * VVS by Rodrigo Prestes Machado
- * 
  * VVS is licensed under a
  * Creative Commons Attribution 4.0 International License.
  * You should have received a copy of the license along with this
  * work. If not, see <http://creativecommons.org/licenses/by/4.0/>.
  *
 */
+
 package junit;
 
+import io.github.bonigarcia.wdm.WebDriverManager;
 import java.util.List;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
-import org.openqa.selenium.Dimension;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
 
 /**
  * Exemplo Selenium/Chrome Driver com Junit.
@@ -27,20 +28,33 @@ public class WebTest {
 
     @BeforeAll
     public static void setUp() {
-        WebTest.driver = new ChromeDriver();
+        WebDriverManager.chromedriver().setup();
+        ChromeOptions options = new ChromeOptions();
+        options.addArguments("--start-maximized");
+        //Rodar no Linux: Usar os arguments no-sandbox
+        //options.addArguments("--no-sandbox"); // Bypass OS security model
+        //options.addArguments("- disable-dev-shm-usage"); // overcome limited resource problems
+
+        WebTest.driver = new ChromeDriver(options);
     }
 
     @AfterAll
     public static void tearDown() {
-        driver.quit();
+
+        if (WebTest.driver != null) {
+
+            WebTest.driver.quit();
+            WebTest.driver = null;
+        }
+
     }
 
     @Test
     @SuppressWarnings("checkstyle:magicnumber")
     public void web() {
+
         WebTest.driver.get("https://ifrs.edu.br/");
-        WebTest.driver.manage().window().setSize(new Dimension(1440, 877));
-        WebTest.driver.findElement(By.linkText("Editais")).click();
+        WebTest.driver.findElement(By.xpath("//li[@id='menu-item-844']/a")).click();
 
         List<WebElement> elements = WebTest.driver.findElements(By.cssSelector(".editais__title"));
         assert elements.size() > 0;


### PR DESCRIPTION
Adiciona nova dependência:

io.github.bonigarcia
**webdrivermanager**

Usando o WebDriverManager, podemos baixar o arquivo binário (ou arquivos .exe) do driver para testes de automação. Neste artigo, discutiremos a importância do WebDriverManager na automação e também como usá-lo no Selenium para testes de automação.

- Novo locator para acessar o menu "Editais" da página. Uso de Xpath.